### PR TITLE
Add chatbot for simple conversational responses

### DIFF
--- a/src/scripts/chatbot.js
+++ b/src/scripts/chatbot.js
@@ -1,0 +1,48 @@
+
+// Simple rule-based chatbot
+import $ from 'jquery';
+
+const responses = [
+  { pattern: /hola|buenas/i, reply: '¡Hola! ¿En qué puedo ayudarte?' },
+  { pattern: /qu[ié]n eres|quien eres/i, reply: 'Soy un bot conversacional de ejemplo.' },
+  { pattern: /adi[oó]s|chau/i, reply: '¡Adiós! Espero haberte ayudado.' }
+];
+
+function getReply(text) {
+  for (const r of responses) {
+    if (r.pattern.test(text)) {
+      return r.reply;
+    }
+  }
+  return 'Lo siento, no entendí eso.';
+}
+
+function addMessage(sender, text) {
+  const message = $('<div>').addClass('chat-message').addClass(sender).text(text);
+  $('.chat-content').append(message);
+  $('.chat-content').scrollTop($('.chat-content')[0].scrollHeight);
+}
+
+export default function initChatbot() {
+  const chat = $(
+    '<div class="chat-bot">\
+      <div class="chat-content"></div>\
+      <form class="chat-form">\
+        <input type="text" class="chat-input" placeholder="Escribe un mensaje..." />\
+        <button type="submit">Enviar</button>\
+      </form>\
+    </div>'
+  );
+  $('body').append(chat);
+
+  $('.chat-form').on('submit', function(e) {
+    e.preventDefault();
+    const input = $('.chat-input');
+    const text = input.val().trim();
+    if (!text) return;
+    addMessage('user', text);
+    input.val('');
+    const reply = getReply(text);
+    setTimeout(() => addMessage('bot', reply), 300);
+  });
+}

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -2,3 +2,9 @@ import {} from 'jquery-sticky/jquery.sticky';
 import {} from 'jquery.scrollto/jquery.scrollTo';
 import '../styles/index.scss';
 import './custom';
+import initChatbot from './chatbot';
+
+// Initialize simple chatbot on page load
+document.addEventListener('DOMContentLoaded', () => {
+  initChatbot();
+});

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -2,3 +2,52 @@
 // @import '../fonts/font';
 @import 'all';
 @import 'scroll-down';
+
+// Chatbot styles
+.chat-bot {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 260px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  z-index: 1000;
+}
+.chat-content {
+  flex: 1;
+  padding: 0.5rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.chat-message {
+  margin-bottom: 0.5rem;
+}
+.chat-message.bot {
+  color: #333;
+}
+.chat-message.user {
+  text-align: right;
+  color: #007bff;
+}
+.chat-form {
+  display: flex;
+  border-top: 1px solid #ccc;
+}
+.chat-input {
+  flex: 1;
+  border: none;
+  padding: 0.3rem;
+  font-size: 14px;
+}
+.chat-form button {
+  background: #007bff;
+  color: #fff;
+  border: none;
+  padding: 0 0.5rem;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- introduce minimal chatbot logic that responds to a few phrases
- mount chatbot on load in index.js
- style the chatbot widget in `index.scss`

## Testing
- `npm install` *(fails: node-sass build requires python2)*

------
https://chatgpt.com/codex/tasks/task_e_6886dac0915c8324856d8c9143638ffd